### PR TITLE
Fixs “rps_version” unexpectedly does not exist error during update.

### DIFF
--- a/migrations/release_1_4_1.php
+++ b/migrations/release_1_4_1.php
@@ -26,7 +26,7 @@ class release_1_4_1 extends migration
 	 */
 	public function effectively_installed()
 	{
-		return isset($this->config['quickstyle_version']) && version_compare($this->config['rt_version'], '1.4.1', '>=');
+		return isset($this->config['quickstyle_version']) && version_compare($this->config['quickstyle_version'], '1.4.1', '>=');
 	}
 
 	/**
@@ -45,7 +45,7 @@ class release_1_4_1 extends migration
 	public function update_data()
 	{
 		return array(
-			array('config.update', array('rps_version', '1.4.1')),
+			array('config.update', array('quickstyle_version', '1.4.1')),
 		);
 	}
 }

--- a/migrations/release_1_4_2.php
+++ b/migrations/release_1_4_2.php
@@ -14,11 +14,11 @@ namespace paybas\quickstyle\migrations;
 use phpbb\db\migration\migration;
 
 /**
- * Class release_1_4_0
+ * Class release_1_4_2
  *
  * @package paybas\quickstyle\migrations
  */
-class release_1_4_0 extends migration
+class release_1_4_2 extends migration
 {
 
 	/**
@@ -26,7 +26,7 @@ class release_1_4_0 extends migration
 	 */
 	public function effectively_installed()
 	{
-		return isset($this->config['quickstyle_version']) && version_compare($this->config['quickstyle_version'], '1.4.0', '>=');
+		return isset($this->config['quickstyle_version']) && version_compare($this->config['quickstyle_version'], '1.4.2', '>=');
 	}
 
 	/**
@@ -35,7 +35,7 @@ class release_1_4_0 extends migration
 	static public function depends_on()
 	{
 		return array(
-			'\paybas\quickstyle\migrations\release_1_3_0',
+			'\paybas\quickstyle\migrations\release_1_4_1',
 		);
 	}
 
@@ -45,7 +45,7 @@ class release_1_4_0 extends migration
 	public function update_data()
 	{
 		return array(
-			array('config.update', array('quickstyle_version', '1.4.0')),
+			array('config.update', array('quickstyle_version', '1.4.2')),
 		);
 	}
 }


### PR DESCRIPTION
Hi @Sajaki,

I fixed this issue: https://github.com/Sajaki/QuickStyle/issues/3.

could you merge this please?

Moreover, I notice that RPS ext here: https://github.com/Sajaki/RankPostStyling/tree/develop32/migrations contains the same type of issues in it migration files.

Regards.